### PR TITLE
Fix broken cross-reference to GeneralPurposeClaims

### DIFF
--- a/openid-connect-federation-1_1.xml
+++ b/openid-connect-federation-1_1.xml
@@ -1917,7 +1917,7 @@ HTTP/1.1 302 Found
       <t>
 	This specification defines no general-purpose JWT Claims.
 	Those defined in
-	<relref section="13" relative="#GeneralPurposeClaims-statement" target="OpenID.Federation-1.1"/>
+	<relref section="13" relative="#GeneralPurposeClaims" target="OpenID.Federation-1.1"/>
 	are used by this specification.
       </t>
     </section>


### PR DESCRIPTION
## Summary

Fix broken cross-reference in Section 13 (General-Purpose JWT Claims).

## Problem

The relref element references an anchor that does not exist in OpenID Federation 1.1:

```xml
<relref section="13" relative="#GeneralPurposeClaims-statement" target="OpenID.Federation-1.1"/>
```

The anchor `#GeneralPurposeClaims-statement` does not exist. The correct anchor is `#GeneralPurposeClaims`.

## Changes

```xml
<!-- Before -->
<relref section="13" relative="#GeneralPurposeClaims-statement" target="OpenID.Federation-1.1"/>

<!-- After -->
<relref section="13" relative="#GeneralPurposeClaims" target="OpenID.Federation-1.1"/>
```

## References

- [OpenID Federation 1.1 - Section 13](https://openid.github.io/federation-1.1/main.html#GeneralPurposeClaims)

🤖 Generated with [Claude Code](https://claude.ai/code)